### PR TITLE
Improve energy efficiency by applying Cache Energy Pattern

### DIFF
--- a/app/src/main/java/com/nutomic/syncthingandroid/http/ApiRequest.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/http/ApiRequest.java
@@ -31,7 +31,11 @@ import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
 import java.util.Map;
 
-import javax.net.ssl.*;
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.SSLSessionContext;
 
 public abstract class ApiRequest {
 
@@ -169,7 +173,7 @@ public abstract class ApiRequest {
             return super.createConnection(url);
         }
     }
-    
+
     private SSLSocketFactory getSslSocketFactory() {
         try {
             SSLContext sslContext = SSLContext.getInstance("TLS");

--- a/app/src/main/java/com/nutomic/syncthingandroid/http/ApiRequest.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/http/ApiRequest.java
@@ -31,10 +31,7 @@ import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
 import java.util.Map;
 
-import javax.net.ssl.HttpsURLConnection;
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.SSLSocketFactory;
-import javax.net.ssl.TrustManager;
+import javax.net.ssl.*;
 
 public abstract class ApiRequest {
 
@@ -172,13 +169,18 @@ public abstract class ApiRequest {
             return super.createConnection(url);
         }
     }
-
+    
     private SSLSocketFactory getSslSocketFactory() {
         try {
             SSLContext sslContext = SSLContext.getInstance("TLS");
             File httpsCertPath = Constants.getHttpsCertFile(mContext);
             sslContext.init(null, new TrustManager[]{new SyncthingTrustManager(httpsCertPath)},
                     new SecureRandom());
+            SSLSessionContext sslSessionContext = sslContext.getServerSessionContext();
+            int sessionCacheSize = sslSessionContext.getSessionCacheSize();
+            if (sessionCacheSize > 0) {
+                sslSessionContext.setSessionCacheSize(0);
+            }
             return sslContext.getSocketFactory();
         } catch (NoSuchAlgorithmException | KeyManagementException e) {
             Log.w(TAG, e);


### PR DESCRIPTION
This improves the energy efficiency of Catfriend1 by applying the Cache Energy Pattern for mobile applications.

The energy pattern was applied in ApiRequest.java . The general idea is to avoid performing unnecessary operations by increasing the size of the cache used. In particular, when a SSLContext is created, if the size of the cache has a limit, it's set to have no limit.